### PR TITLE
fix(sync): terminal not showing due to :q or :bd

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.10",
+    "@types/which": "^1.3.2",
     "coc.nvim": "^0.0.79",
     "npm-run-all": "^4.1.5",
     "ts-loader": "^8.0.11",
@@ -41,5 +42,8 @@
         "title": "Destroy and free terminal"
       }
     ]
+  },
+  "dependencies": {
+    "which": "^2.0.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { commands, ExtensionContext, Terminal, workspace } from 'coc.nvim';
+import { commands, ExtensionContext, Terminal, workspace, events } from 'coc.nvim';
+import which from "which"
 
 const replAvailableLanguages = ['javascript', 'typescript', 'python'];
 let terminal: Terminal | null = null;
@@ -31,6 +32,19 @@ export async function activate(context: ExtensionContext): Promise<void> {
       { sync: false }
     )
   );
+
+    events.on('BufHidden', async (bufnr) => {
+        if (terminal?.bufnr === bufnr) {
+            showing = false
+        }
+    });
+
+    events.on('BufUnload', async (bufnr) => {
+        if (terminal?.bufnr === bufnr) {
+            terminal = null
+            showing = false
+        }
+    });
 }
 
 async function toggle(): Promise<void> {
@@ -40,6 +54,10 @@ async function toggle(): Promise<void> {
       workspace.showMessage(`Create terminal failed`, 'error');
       return;
     }
+
+    // hack to make startinsert work
+    terminal.sendText("", false)
+    await workspace.nvim.command('startinsert');
   }
 
   if (showing) {
@@ -63,7 +81,7 @@ async function repl(): Promise<void> {
   if (filetype === 'javascript') {
     prog = 'node';
   } else if (filetype === 'typescript') {
-    prog = 'ts-node';
+    prog = which.sync('ts-node', {nothrow: true}) ? 'ts-node' : 'node';
   } else if (filetype === 'python') {
     prog = 'python';
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
             showing = false
         }
     });
+
+    events.on('BufEnter', async (bufnr) => {
+        if (terminal?.bufnr === bufnr) {
+            terminal.sendText("", false)
+            await workspace.nvim.command('startinsert');
+        }
+    });
 }
 
 async function toggle(): Promise<void> {
@@ -54,10 +61,6 @@ async function toggle(): Promise<void> {
       workspace.showMessage(`Create terminal failed`, 'error');
       return;
     }
-
-    // hack to make startinsert work
-    terminal.sendText("", false)
-    await workspace.nvim.command('startinsert');
   }
 
   if (showing) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.11.tgz#fc25a4248a5e8d0837019b1d170146d07334abe0"
   integrity sha512-BJ97wAUuU3NUiUCp44xzUFquQEvnk1wu7q4CMEUYKJWjdkr0YWYDsm4RFtAvxYsNjLsKcrFt6RvK8r+mnzMbEQ==
 
+"@types/which@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-1.3.2.tgz#9c246fc0c93ded311c8512df2891fb41f6227fdf"
+  integrity sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"


### PR DESCRIPTION
this does:
1. listen on `BufHidden`, change showing to false. This happens when user exit the terminal using :q
2. listen on `BufUnload`, reset terminal & showing. This happens when terminal buffer was deleted. for example by mappings:

    ```
    tnoremap <Esc> <C-\><C-n>:bd!<CR>
    ```
3. fallback to node when ts-node doesn't exits, which however add a dependency
4. startinsert while coming back to terminal (`BufEnter`) to make the following mapping work
    ```
    nmap <m-=> <Plug>(coc-terminal-toggle)
    tnoremap <m-=>  <C-\><C-n>:q<CR>
    ```